### PR TITLE
Fix arena white screen and store user selection

### DIFF
--- a/js/store.js
+++ b/js/store.js
@@ -1150,12 +1150,25 @@ class StoreSystem {
         GameUtils.saveToLocalStorage('store_data', storeData);
     }
 
+    addFreeItems() {
+        // Add all free items to owned items
+        const allItems = this.getAllItems();
+        allItems.forEach(item => {
+            if (item.price === 0) {
+                this.ownedItems.add(item.id);
+            }
+        });
+    }
+
     loadFromStorage() {
         const storeData = GameUtils.loadFromLocalStorage('store_data', {});
         
         if (storeData.ownedItems) {
             this.ownedItems = new Set(storeData.ownedItems);
         }
+        
+        // Ensure free items are always owned
+        this.addFreeItems();
         
         if (storeData.chronoPassData) {
             // Merge with default data to handle new properties

--- a/styles.css
+++ b/styles.css
@@ -616,6 +616,26 @@ body {
     box-shadow: 0 0 20px rgba(0, 255, 255, 0.4);
 }
 
+.store-item.owned {
+    border-color: rgba(0, 255, 0, 0.5);
+}
+
+.store-item.equipped {
+    border-color: #ffaa00;
+    box-shadow: 0 0 20px rgba(255, 170, 0, 0.4);
+    background: rgba(255, 170, 0, 0.1);
+}
+
+.store-item.equipped .item-price {
+    color: #ffaa00;
+    font-weight: bold;
+}
+
+.store-item.locked {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .store-item-preview {
     width: 100%;
     height: 120px;
@@ -638,6 +658,42 @@ body {
     font-family: 'Orbitron', monospace;
     color: #ffff00;
     font-weight: 700;
+}
+
+.buy-button, .equip-button {
+    background: linear-gradient(45deg, #00ffff, #0088ff);
+    border: none;
+    border-radius: 6px;
+    color: #000000;
+    font-family: 'Orbitron', monospace;
+    font-weight: 600;
+    font-size: 0.9rem;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    transition: all 0.3s ease;
+    text-transform: uppercase;
+    margin-top: 0.5rem;
+}
+
+.buy-button:hover, .equip-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 3px 15px rgba(0, 255, 255, 0.6);
+}
+
+.buy-button:disabled {
+    background: rgba(128, 128, 128, 0.5);
+    color: rgba(255, 255, 255, 0.5);
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+}
+
+.equip-button {
+    background: linear-gradient(45deg, #ffaa00, #ff8800);
+}
+
+.equip-button:hover {
+    box-shadow: 0 3px 15px rgba(255, 170, 0, 0.6);
 }
 
 /* Settings Styles */


### PR DESCRIPTION
Fixes white screen on game start and enhances store to display and allow equipping of cosmetic items.

The game canvas and HUD were hidden by `hideAllScreens()` but not re-shown in `startGame()` and `respawn()`, causing a blank screen. The store lacked visual cues for equipped items and an equip mechanism, which is now added along with ensuring free items are always owned.

---
<a href="https://cursor.com/background-agent?bcId=bc-fc1f97b1-b358-4efc-a1e7-66af0470bf9b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fc1f97b1-b358-4efc-a1e7-66af0470bf9b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

